### PR TITLE
Add Dockerfile for containerization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,38 @@
-FROM python:3.10-slim
+FROM python:3.13 as requirements_stage
 
-# Set the working directory
+WORKDIR /wheel
+
+RUN python -m pip install --user pipx
+
+COPY ./pyproject.toml \
+  ./requirements.txt \
+  /wheel/
+
+
+RUN python -m pip wheel --wheel-dir=/wheel --no-cache-dir --requirement ./requirements.txt
+
+RUN python -m pipx run --no-cache nb-cli generate -f /tmp/bot.py
+
+
+FROM python:3.13-slim
+
 WORKDIR /app
 
-# Copy the project files to the container
-COPY . /app
+ENV TZ Asia/Shanghai
+ENV PYTHONPATH=/app
 
-# Create and activate a virtual environment
-RUN python -m venv .venv \
-    && . .venv/bin/activate \
-    && pip install --no-cache-dir -r requirements.txt \
-    && pip install nonebot2 nonebot-adapter-onebot
+COPY ./docker/gunicorn_conf.py ./docker/start.sh /
+RUN chmod +x /start.sh
 
-# Expose port 8080
-EXPOSE 8080
+ENV APP_MODULE _main:app
+ENV MAX_WORKERS 1
 
-# Set the default command to run the bot
-CMD [".venv/bin/nb", "run"]
+COPY --from=requirements_stage /tmp/bot.py /app
+COPY ./docker/_main.py /app
+COPY --from=requirements_stage /wheel /wheel
+
+RUN pip install --no-cache-dir gunicorn uvicorn[standard] nonebot2 \
+  && pip install --no-cache-dir --no-index --force-reinstall --find-links=/wheel -r /wheel/requirements.txt && rm -rf /wheel
+COPY . /app/
+
+CMD ["/start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.10-slim
+
+# Set the working directory
+WORKDIR /app
+
+# Copy the project files to the container
+COPY . /app
+
+# Create and activate a virtual environment
+RUN python -m venv .venv \
+    && . .venv/bin/activate \
+    && pip install --no-cache-dir -r requirements.txt \
+    && pip install nonebot2 nonebot-adapter-onebot
+
+# Expose port 8080
+EXPOSE 8080
+
+# Set the default command to run the bot
+CMD [".venv/bin/nb", "run"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+nonebot2\nnonebot-adapter-onebot


### PR DESCRIPTION
Add a Dockerfile to set up the project environment using the official Python 3.10 image.

* **Base Image**
  - Use `python:3.10-slim` as the base image.

* **Working Directory**
  - Set the working directory to `/app`.

* **Project Files**
  - Copy the project files to the container.

* **Virtual Environment**
  - Create and activate a virtual environment.
  - Install dependencies from `requirements.txt` and additional packages `nonebot2` and `nonebot-adapter-onebot`.

* **Port Exposure**
  - Expose port 8080.

* **Default Command**
  - Set the default command to run the bot using `nb run`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/GengGode/split-msg-bot/pull/1?shareId=ae41b085-cd28-40f0-8544-be9033d88ca2).